### PR TITLE
[Router] Enforce redeem outflow limitations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxd-cpi"
-version = "8.1.3"
+version = "8.1.4"
 authors = [
   "acammm <alexcamill@gmail.com>",
   "cnek <ctk2012ac@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxd-cpi"
-version = "8.1.2"
+version = "8.1.3"
 authors = [
   "acammm <alexcamill@gmail.com>",
   "cnek <ctk2012ac@gmail.com>",

--- a/idl.json
+++ b/idl.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.1.0",
+  "version": "8.1.4",
   "name": "uxd",
   "instructions": [
     {
@@ -542,6 +542,12 @@
           "isMut": false,
           "isSigner": false,
           "docs": ["#21"]
+        },
+        {
+          "name": "clock",
+          "isMut": false,
+          "isSigner": false,
+          "docs": ["#22"]
         }
       ],
       "args": [
@@ -2172,21 +2178,21 @@
             "type": "u16"
           },
           {
-            "name": "secondsPerEpoch",
-            "type": "u32"
+            "name": "slotsPerEpoch",
+            "type": "u64"
           },
           {
             "name": "epochOutflowAmount",
             "type": "u64"
           },
           {
-            "name": "lastOutflowTimestamp",
-            "type": "i64"
+            "name": "lastOutflowSlot",
+            "type": "u64"
           },
           {
             "name": "reserved",
             "type": {
-              "array": ["u8", 98]
+              "array": ["u8", 94]
             }
           }
         ]
@@ -2574,9 +2580,9 @@
             }
           },
           {
-            "name": "secondsPerEpoch",
+            "name": "slotsPerEpoch",
             "type": {
-              "option": "u32"
+              "option": "u64"
             }
           }
         ]
@@ -2723,7 +2729,7 @@
       ]
     },
     {
-      "name": "SetSecondsPerEpochEvent",
+      "name": "SetSlotsPerEpochEvent",
       "fields": [
         {
           "name": "version",
@@ -2736,8 +2742,8 @@
           "index": false
         },
         {
-          "name": "secondsPerEpoch",
-          "type": "u32",
+          "name": "slotsPerEpoch",
+          "type": "u64",
           "index": false
         }
       ]

--- a/idl.json
+++ b/idl.json
@@ -566,56 +566,56 @@
           "name": "user",
           "isMut": false,
           "isSigner": true,
-          "docs": ["#1"]
+          "docs": ["#2"]
         },
         {
           "name": "payer",
           "isMut": true,
           "isSigner": true,
-          "docs": ["#2"]
+          "docs": ["#3"]
         },
         {
           "name": "controller",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#3"]
+          "docs": ["#4"]
         },
         {
           "name": "depository",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#4"]
+          "docs": ["#5"]
         },
         {
           "name": "redeemableMint",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#5"]
+          "docs": ["#6"]
         },
         {
           "name": "userRedeemable",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#6"]
+          "docs": ["#7"]
         },
         {
           "name": "collateralMint",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#7"]
+          "docs": ["#8"]
         },
         {
           "name": "userCollateral",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#8"]
+          "docs": ["#9"]
         },
         {
           "name": "depositoryLpTokenVault",
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#9",
+            "#10",
             "Token account holding the LP tokens minted by depositing collateral on mercurial vault"
           ]
         },
@@ -623,20 +623,20 @@
           "name": "mercurialVault",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#10"]
+          "docs": ["#11"]
         },
         {
           "name": "mercurialVaultLpMint",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#11"]
+          "docs": ["#12"]
         },
         {
           "name": "mercurialVaultCollateralTokenSafe",
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#12",
+            "#13",
             "Token account owned by the mercurial vault program. Hold the collateral deposited in the mercurial vault."
           ]
         },
@@ -644,19 +644,19 @@
           "name": "mercurialVaultProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#13"]
+          "docs": ["#14"]
         },
         {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#14"]
+          "docs": ["#15"]
         },
         {
           "name": "tokenProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#15"]
+          "docs": ["#16"]
         }
       ],
       "args": [
@@ -769,56 +769,56 @@
           "name": "user",
           "isMut": false,
           "isSigner": true,
-          "docs": ["#1"]
+          "docs": ["#2"]
         },
         {
           "name": "payer",
           "isMut": true,
           "isSigner": true,
-          "docs": ["#2"]
+          "docs": ["#3"]
         },
         {
           "name": "controller",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#3"]
+          "docs": ["#4"]
         },
         {
           "name": "depository",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#4"]
+          "docs": ["#5"]
         },
         {
           "name": "redeemableMint",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#5"]
+          "docs": ["#6"]
         },
         {
           "name": "userRedeemable",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#6"]
+          "docs": ["#7"]
         },
         {
           "name": "collateralMint",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#7"]
+          "docs": ["#8"]
         },
         {
           "name": "userCollateral",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#8"]
+          "docs": ["#9"]
         },
         {
           "name": "depositoryLpTokenVault",
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#9",
+            "#10",
             "Token account holding the LP tokens minted by depositing collateral on mercurial vault"
           ]
         },
@@ -826,20 +826,20 @@
           "name": "mercurialVault",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#10"]
+          "docs": ["#11"]
         },
         {
           "name": "mercurialVaultLpMint",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#11"]
+          "docs": ["#12"]
         },
         {
           "name": "mercurialVaultCollateralTokenSafe",
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#12",
+            "#13",
             "Token account owned by the mercurial vault program. Hold the collateral deposited in the mercurial vault."
           ]
         },
@@ -847,19 +847,19 @@
           "name": "mercurialVaultProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#13"]
+          "docs": ["#14"]
         },
         {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#14"]
+          "docs": ["#15"]
         },
         {
           "name": "tokenProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#15"]
+          "docs": ["#16"]
         }
       ],
       "args": [
@@ -1034,20 +1034,20 @@
           "name": "user",
           "isMut": false,
           "isSigner": true,
-          "docs": ["#1 Public call accessible to any user"]
+          "docs": ["#2"]
         },
         {
           "name": "payer",
           "isMut": true,
           "isSigner": true,
-          "docs": ["#2"]
+          "docs": ["#3"]
         },
         {
           "name": "controller",
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#3 The top level UXDProgram on chain account managing the redeemable mint"
+            "#4 The top level UXDProgram on chain account managing the redeemable mint"
           ]
         },
         {
@@ -1055,21 +1055,21 @@
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#4 UXDProgram on chain account bound to a Controller instance that represent the blank minting/redeeming"
+            "#5 UXDProgram on chain account bound to a Controller instance that represent the blank minting/redeeming"
           ]
         },
         {
           "name": "collateralVault",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#5", "Token account holding the collateral from minting"]
+          "docs": ["#6", "Token account holding the collateral from minting"]
         },
         {
           "name": "redeemableMint",
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#6 The redeemable mint managed by the `controller` instance",
+            "#7 The redeemable mint managed by the `controller` instance",
             "Tokens will be minted during this instruction"
           ]
         },
@@ -1078,7 +1078,7 @@
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#7 The `user`'s TA for the `depository` `collateral_mint`",
+            "#8 The `user`'s TA for the `depository` `collateral_mint`",
             "Will be debited during this instruction"
           ]
         },
@@ -1087,7 +1087,7 @@
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#8 The `user`'s TA for the `controller`'s `redeemable_mint`",
+            "#9 The `user`'s TA for the `controller`'s `redeemable_mint`",
             "Will be credited during this instruction"
           ]
         },
@@ -1095,13 +1095,13 @@
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#9"]
+          "docs": ["#10"]
         },
         {
           "name": "tokenProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#10 Token Program"]
+          "docs": ["#11 Token Program"]
         }
       ],
       "args": [
@@ -1126,20 +1126,20 @@
           "name": "user",
           "isMut": false,
           "isSigner": true,
-          "docs": ["#1 Public call accessible to any user"]
+          "docs": ["#2"]
         },
         {
           "name": "payer",
           "isMut": true,
           "isSigner": true,
-          "docs": ["#2"]
+          "docs": ["#3"]
         },
         {
           "name": "controller",
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#3 The top level UXDProgram on chain account managing the redeemable mint"
+            "#4 The top level UXDProgram on chain account managing the redeemable mint"
           ]
         },
         {
@@ -1147,14 +1147,14 @@
           "isMut": true,
           "isSigner": false,
           "docs": [
-            "#4 UXDProgram on chain account bound to a Controller instance that represent the blank minting/redeeming"
+            "#5 UXDProgram on chain account bound to a Controller instance that represent the blank minting/redeeming"
           ]
         },
         {
           "name": "collateralVault",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#5", "Token account holding the collateral from minting"]
+          "docs": ["#6", "Token account holding the collateral from minting"]
         },
         {
           "name": "redeemableMint",
@@ -1333,121 +1333,121 @@
           "name": "user",
           "isMut": false,
           "isSigner": true,
-          "docs": ["#1"]
+          "docs": ["#2"]
         },
         {
           "name": "payer",
           "isMut": true,
           "isSigner": true,
-          "docs": ["#2"]
+          "docs": ["#3"]
         },
         {
           "name": "controller",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#3"]
+          "docs": ["#4"]
         },
         {
           "name": "depository",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#4"]
+          "docs": ["#5"]
         },
         {
           "name": "redeemableMint",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#5"]
+          "docs": ["#6"]
         },
         {
           "name": "collateralMint",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#6"]
+          "docs": ["#7"]
         },
         {
           "name": "userRedeemable",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#7"]
+          "docs": ["#8"]
         },
         {
           "name": "userCollateral",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#8"]
+          "docs": ["#9"]
         },
         {
           "name": "depositoryCollateral",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#9"]
+          "docs": ["#10"]
         },
         {
           "name": "depositoryShares",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#10"]
+          "docs": ["#11"]
         },
         {
           "name": "credixGlobalMarketState",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#11"]
+          "docs": ["#12"]
         },
         {
           "name": "credixSigningAuthority",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#12"]
+          "docs": ["#13"]
         },
         {
           "name": "credixLiquidityCollateral",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#13"]
+          "docs": ["#14"]
         },
         {
           "name": "credixSharesMint",
           "isMut": true,
           "isSigner": false,
-          "docs": ["#14"]
+          "docs": ["#15"]
         },
         {
           "name": "credixPass",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#15"]
+          "docs": ["#16"]
         },
         {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#16"]
+          "docs": ["#17"]
         },
         {
           "name": "tokenProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#17"]
+          "docs": ["#18"]
         },
         {
           "name": "associatedTokenProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#18"]
+          "docs": ["#19"]
         },
         {
           "name": "credixProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#19"]
+          "docs": ["#20"]
         },
         {
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#20"]
+          "docs": ["#21"]
         }
       ],
       "args": [
@@ -2164,9 +2164,29 @@
             "type": "publicKey"
           },
           {
+            "name": "outflowLimitPerEpochAmount",
+            "type": "u64"
+          },
+          {
+            "name": "outflowLimitPerEpochBps",
+            "type": "u16"
+          },
+          {
+            "name": "secondsPerEpoch",
+            "type": "u32"
+          },
+          {
+            "name": "epochOutflowAmount",
+            "type": "u64"
+          },
+          {
+            "name": "lastOutflowTimestamp",
+            "type": "i64"
+          },
+          {
             "name": "reserved",
             "type": {
-              "array": ["u8", 128]
+              "array": ["u8", 98]
             }
           }
         ]
@@ -2540,6 +2560,24 @@
                 "defined": "EditRouterDepositories"
               }
             }
+          },
+          {
+            "name": "outflowLimitPerEpochAmount",
+            "type": {
+              "option": "u64"
+            }
+          },
+          {
+            "name": "outflowLimitPerEpochBps",
+            "type": {
+              "option": "u16"
+            }
+          },
+          {
+            "name": "secondsPerEpoch",
+            "type": {
+              "option": "u32"
+            }
           }
         ]
       }
@@ -2640,6 +2678,66 @@
         {
           "name": "redeemableGlobalSupplyCap",
           "type": "u128",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "SetOutflowLimitPerEpochAmountEvent",
+      "fields": [
+        {
+          "name": "version",
+          "type": "u8",
+          "index": false
+        },
+        {
+          "name": "controller",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "outflowLimitPerEpochAmount",
+          "type": "u64",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "SetOutflowLimitPerEpochBpsEvent",
+      "fields": [
+        {
+          "name": "version",
+          "type": "u8",
+          "index": false
+        },
+        {
+          "name": "controller",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "outflowLimitPerEpochBps",
+          "type": "u16",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "SetSecondsPerEpochEvent",
+      "fields": [
+        {
+          "name": "version",
+          "type": "u8",
+          "index": false
+        },
+        {
+          "name": "controller",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "secondsPerEpoch",
+          "type": "u32",
           "index": false
         }
       ]
@@ -3308,8 +3406,8 @@
     },
     {
       "code": 6012,
-      "name": "MathError",
-      "msg": "Math error."
+      "name": "MathOverflow",
+      "msg": "Math overflow."
     },
     {
       "code": 6013,
@@ -3530,6 +3628,11 @@
       "code": 6056,
       "name": "Default",
       "msg": "Default - Check the source code for more info."
+    },
+    {
+      "code": 6057,
+      "name": "MaximumOutflowAmountError",
+      "msg": "Redeem resulted into too much outflow in this epoch, please wait or try again with a smaller amount."
     }
   ],
   "metadata": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "uxd-cpi",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This is an implementation for the limiting the outflows to a hardcoded amount (or BPS) per epoch (epoch time configurable)

Basically maintain a set of new controller flags, and adds some accounting in the mint/redeem router IXs

PR Combo:
- uxd-client: https://github.com/UXDProtocol/uxd-client/pull/52
- uxd-cpi: https://github.com/UXDProtocol/uxd-cpi/pull/8
- uxd-program: https://github.com/UXDProtocol/uxd-program/pull/288