### PR TITLE
[Credix] Update to 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxd-cpi"
-version = "8.1.6"
+version = "8.2.0"
 authors = [
   "acammm <alexcamill@gmail.com>",
   "cnek <ctk2012ac@gmail.com>",

--- a/idl.json
+++ b/idl.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.1.6",
+  "version": "8.2.0",
   "name": "uxd",
   "instructions": [
     {
@@ -3594,13 +3594,13 @@
     },
     {
       "code": 6052,
-      "name": "InvalidCredixMultisigKey",
-      "msg": "The Credix Multisig Key isn't the ProgramState one."
+      "name": "InvalidCredixTreasury",
+      "msg": "The Credix Treasury isn't the ProgramState one."
     },
     {
       "code": 6053,
-      "name": "InvalidCredixTreasuryCollateral",
-      "msg": "The Credix TreasuryCollateral isn't the GlobalMarketState one."
+      "name": "InvalidCredixTreasuryPoolCollateral",
+      "msg": "The Credix TreasuryPool isn't the GlobalMarketState one."
     },
     {
       "code": 6054,

--- a/idl.json
+++ b/idl.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.1.4",
+  "version": "8.1.6",
   "name": "uxd",
   "instructions": [
     {
@@ -1557,19 +1557,19 @@
           "docs": ["#16"]
         },
         {
-          "name": "credixTreasuryCollateral",
+          "name": "credixTreasuryPoolCollateral",
           "isMut": true,
           "isSigner": false,
           "docs": ["#17"]
         },
         {
-          "name": "credixMultisigKey",
+          "name": "credixTreasury",
           "isMut": false,
           "isSigner": false,
           "docs": ["#18"]
         },
         {
-          "name": "credixMultisigCollateral",
+          "name": "credixTreasuryCollateral",
           "isMut": true,
           "isSigner": false,
           "docs": ["#19"]
@@ -1688,19 +1688,19 @@
           "docs": ["#12"]
         },
         {
-          "name": "credixTreasuryCollateral",
+          "name": "credixTreasuryPoolCollateral",
           "isMut": true,
           "isSigner": false,
           "docs": ["#13"]
         },
         {
-          "name": "credixMultisigKey",
+          "name": "credixTreasury",
           "isMut": false,
           "isSigner": false,
           "docs": ["#14"]
         },
         {
-          "name": "credixMultisigCollateral",
+          "name": "credixTreasuryCollateral",
           "isMut": true,
           "isSigner": false,
           "docs": ["#15"]
@@ -1829,22 +1829,16 @@
           "docs": ["#13"]
         },
         {
-          "name": "credixWithdrawRequest",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["#14"]
-        },
-        {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#15"]
+          "docs": ["#14"]
         },
         {
           "name": "credixProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#16"]
+          "docs": ["#15"]
         }
       ],
       "args": []
@@ -1945,19 +1939,19 @@
           "docs": ["#15"]
         },
         {
-          "name": "credixTreasuryCollateral",
+          "name": "credixTreasuryPoolCollateral",
           "isMut": true,
           "isSigner": false,
           "docs": ["#16"]
         },
         {
-          "name": "credixMultisigKey",
+          "name": "credixTreasury",
           "isMut": false,
           "isSigner": false,
           "docs": ["#17"]
         },
         {
-          "name": "credixMultisigCollateral",
+          "name": "credixTreasuryCollateral",
           "isMut": true,
           "isSigner": false,
           "docs": ["#18"]
@@ -1969,46 +1963,40 @@
           "docs": ["#19"]
         },
         {
-          "name": "credixWithdrawRequest",
+          "name": "profitsBeneficiaryCollateral",
           "isMut": true,
           "isSigner": false,
           "docs": ["#20"]
         },
         {
-          "name": "profitsBeneficiaryCollateral",
-          "isMut": true,
-          "isSigner": false,
-          "docs": ["#21"]
-        },
-        {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#22"]
+          "docs": ["#21"]
         },
         {
           "name": "tokenProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#23"]
+          "docs": ["#22"]
         },
         {
           "name": "associatedTokenProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#24"]
+          "docs": ["#23"]
         },
         {
           "name": "credixProgram",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#25"]
+          "docs": ["#24"]
         },
         {
           "name": "rent",
           "isMut": false,
           "isSigner": false,
-          "docs": ["#26"]
+          "docs": ["#25"]
         }
       ],
       "args": []


### PR DESCRIPTION
## TLDR Summary:
<img width="956" alt="Screenshot 2023-09-15 at 12 49 33 PM" src="https://github.com/UXDProtocol/uxd-program/assets/106254129/8a21ac83-89f5-46fd-b09b-bfc08dd9356b">

## PR Combo:
- uxd-client: https://github.com/UXDProtocol/uxd-client/pull/57
- uxd-program: https://github.com/UXDProtocol/uxd-program/pull/300
- uxd-cpi: https://github.com/UXDProtocol/uxd-cpi/pull/12

## [UXD] Changes updates recap:
 - A) We update the usage of `credix_treasury` -> `credix_treasury_pool`
 - B) We update the usage of `credix_multisig` -> `credix_treasury`
 - C) We make sure to not mistake `treasury_pool` with `credix_treasury` which are now 2 completely different things
 - D) We remove the usage of `withdraw_request`
 - E) We use the new calculation function to compute the withdrawable amount during credix redeem
 - F) We update the tests to work with latest version

## [CREDIX] Change Log:
### Breaking:
- feat: credix pass now has flags instead of boolean fields in the struct. All the fields are exposed by functions.
- feat: withdraw epochs now do the rebalancing, the redeem base locked for investor calculation now take request amount and lp owned both into account. (withdraw request account was removed from contexts)
- feat: Repayment schedule's periods now have calculation date. Describing on what date the accrual will be calculated from.
feat: Membership fee calculations are not based on the yearly outstanding principal
- feat: Program State now has credix treasury. Credix treasury is where the credix fees will be collected from now on.

### For Integrators:
Required changes for integrators in there smart contract:

- If any field example(is_active, is_investor) from the credix pass is used. Replace it with (is_active(), is_investor()...)
- Remove withdraw Request accounts from the cpi calls. 
- Mark withdraw epoch mutable if it is already not when creating withdraw request or redeeming withdraw requests.
- For Redeem withdraw request and withdraw funds. Change the credix_muiltisig -> credix_treasury. And Credix_muiltisig_token_account-> credix_treasury_token_account. The correct credix_treasury address is in program_state account of credix program. 

- To get the max amounts that can be withdrawn in the withdraw Epoch. We have provided a function in the rust client.

### Changes required for there local setup:
- When sending the repayment schedule with set_repayment_schedule we can directly send the RepaymentPeriod instead of RepaymentPeriodsInput struct which previously existed. The calculation_date in the periods can be set equal to the period's time_frame.start.
